### PR TITLE
Align Svelte implementation with all the others

### DIFF
--- a/svelte/client/page.svelte
+++ b/svelte/client/page.svelte
@@ -17,7 +17,7 @@
     let y = centerY + Math.sin(angle) * radius
 
     if (x >= 0 && x <= wrapperWidth - cellSize && y >= 0 && y <= wrapperHeight - cellSize) {
-      tiles = [...tiles, { x, y, id: idCounter++ }]
+      tiles.push({ x, y, id: idCounter++ })
     }
 
     angle += 0.2


### PR DESCRIPTION
Every implementation does `tiles.push` except for the Svelte one, which does `tiles = [...tiles, ...]`. That's the only reason Svelte is slower than the others.

If you make the implementations more similar, Svelte outpaces React, Solid and Vue at least according to my local tests with autocannon. If you use Svelte 5 instead of Svelte 3 (I'll open a separate PR for that), it's faster than the `fastify-html` test:

```
fastify-html — 735.4
react - 136.6
solid - 558.4
svelte - 134
vue - 115.4

svelte fixed — 752.3
svelte@next — 872.6
```

(Note that Vue is slower than React. I'm not sure why you got such different results there.)