### PR TITLE
Remove style tag from Svelte implementation

### DIFF
--- a/svelte/client/page.svelte
+++ b/svelte/client/page.svelte
@@ -24,21 +24,6 @@
   }
 </script>
 
-<style>
-  #wrapper {
-    width: 960px;
-    height: 720px;
-    position: relative;
-    background-color: white;
-  }
-  .tile {
-    position: absolute;
-    width: 10px;
-    height: 10px;
-    background-color: #333;
-  }
-</style>
-
 <div id="wrapper">
   {#each tiles as { x, y }}
     <div


### PR DESCRIPTION
With #5 merged, all other implementations don't contain style tags in their implementation. This therefore removes it for Svelte, too.

Granted, it would be more idiomatic to do keep them, but the same is true for Vue, and the removal was approved in #5, so it seems only fair to also remove it here.

This results in a modest speed improvement (run on a Windows laptop, so all the numbers are lower 😄)

Before

```
Running 10s test @ http://localhost:3000
10 connections


┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬───────┐     
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max   │     
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼───────┤     
│ Latency │ 11 ms │ 13 ms │ 20 ms │ 22 ms │ 13.53 ms │ 2.28 ms │ 43 ms │     
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴───────┘     
┌───────────┬────────┬────────┬────────┬────────┬────────┬─────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg    │ Stdev   │ Min    │
├───────────┼────────┼────────┼────────┼────────┼────────┼─────────┼────────┤
│ Req/Sec   │ 597    │ 597    │ 724    │ 749    │ 711,5  │ 42,33   │ 597    │
├───────────┼────────┼────────┼────────┼────────┼────────┼─────────┼────────┤    
│ Bytes/Sec │ 143 MB │ 143 MB │ 174 MB │ 180 MB │ 171 MB │ 10.1 MB │ 143 MB │    
└───────────┴────────┴────────┴────────┴────────┴────────┴─────────┴────────┘    

Req/Bytes counts sampled once per second.
# of samples: 10

7k requests in 10.04s, 1.71 GB read
```

After

```
Running 10s test @ http://localhost:3000
10 connections


┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬───────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max   │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼───────┤
│ Latency │ 11 ms │ 13 ms │ 19 ms │ 22 ms │ 13.68 ms │ 2.06 ms │ 35 ms │
┌───────────┬────────┬────────┬────────┬────────┬────────┬─────────┬────────┐    
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg    │ Stdev   │ Min    │    
├───────────┼────────┼────────┼────────┼────────┼────────┼─────────┼────────┤    
│ Req/Sec   │ 667    │ 667    │ 702    │ 753    │ 704,7  │ 27,97   │ 667    │    
├───────────┼────────┼────────┼────────┼────────┼────────┼─────────┼────────┤    
│ Bytes/Sec │ 137 MB │ 137 MB │ 145 MB │ 155 MB │ 145 MB │ 5.77 MB │ 137 MB │    
└───────────┴────────┴────────┴────────┴────────┴────────┴─────────┴────────┘    

Req/Bytes counts sampled once per second.
# of samples: 10

7k requests in 10.04s, 1.45 GB read
```