### PR TITLE
Use no-hydration SSR methods for better comparison (React `renderToStaticMarkup` for example)

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -14,6 +14,7 @@
     "fastify": "^4.28.1",
     "react": "19.0.0-rc-f90a6bcc-20240827",
     "react-dom": "19.0.0-rc-f90a6bcc-20240827",
+    "react-markup": "0.0.0-experimental-f90a6bcc-20240827",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/react/pnpm-lock.yaml
+++ b/react/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-f90a6bcc-20240827
         version: 19.0.0-rc-f90a6bcc-20240827(react@19.0.0-rc-f90a6bcc-20240827)
+      react-markup:
+        specifier: 0.0.0-experimental-f90a6bcc-20240827
+        version: 0.0.0-experimental-f90a6bcc-20240827(react@19.0.0-rc-f90a6bcc-20240827)
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -1496,6 +1499,11 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-markup@0.0.0-experimental-f90a6bcc-20240827:
+    resolution: {integrity: sha512-zGnCkbqJVmI+i3DeQB4bwjVbh51OkrKGDdSWOmPNEV0pblnEkPlMzwFrkDn+S0E6zXGkEllVfhXg3vcss0IDMg==}
+    peerDependencies:
+      react: 0.0.0-experimental-f90a6bcc-20240827
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -3409,6 +3417,10 @@ snapshots:
       scheduler: 0.25.0-rc-f90a6bcc-20240827
 
   react-is@16.13.1: {}
+
+  react-markup@0.0.0-experimental-f90a6bcc-20240827(react@19.0.0-rc-f90a6bcc-20240827):
+    dependencies:
+      react: 19.0.0-rc-f90a6bcc-20240827
 
   react-refresh@0.14.2: {}
 

--- a/react/server.js
+++ b/react/server.js
@@ -2,7 +2,8 @@
 import { fileURLToPath } from 'node:url'
 import Fastify from 'fastify'
 import FastifyVite from '@fastify/vite'
-import { renderToString } from 'react-dom/server'
+// eslint-disable-next-line camelcase
+import { experimental_renderToHTML } from 'react-markup'
 
 export async function main (dev) {
   const server = Fastify()
@@ -13,7 +14,7 @@ export async function main (dev) {
     createRenderFunction ({ createApp }) {
       return () => {
         return {
-          element: renderToString(createApp())
+          element: experimental_renderToHTML(createApp())
         }
       }
     }


### PR DESCRIPTION
For React and hydration-based frameworks, I think it's not apple to apple comparison with those that do not hydrate.

Frameworks like React have methods for generating HTML not meant to be hydrated, that may perform better than `renderToString`, and using those would be a better apple to apple comparison with fastify-html, fastify-htmx etc.

Note: even though it's not the common case, it's perfectly valid to use React as a server-side templating framework. This is how Docusaurus v1 used to work: it didn't hydrate React on the client. 

I think to be fair, it makes sense to expose benchmark results for both modes when possible: React with/without hydration capacity.

---

[ReactDOMServer.renderToStaticMarkup](https://react.dev/reference/react-dom/server/renderToStaticMarkup) is a stable method you can use today, but it marginally improves performance according to what I see (only 1-5%?)

[`ReactMarkup.experimental_renderToHTML`](https://github.com/reactjs/react.dev/pull/7107) is its [upcoming successor](https://github.com/facebook/react/pull/30105) (not sure it will be in React 19 stable?) but isn't significantly faster either.

I'm mostly opening this PR as a POC not meant to be merged, and aiming to open the discussion on hydration vs no hydration which may lead to different SSR performance for each framework.
