### PR TITLE
Align implementations around keying

### DIFF
--- a/fastify-html/server.js
+++ b/fastify-html/server.js
@@ -42,7 +42,6 @@ export async function main () {
       !${tiles.map((tile) => (
         server.html`<div
           class="tile"
-          data-key="${tile.id}"
           style="left: ${tile.x}px; top: ${tile.y}px"></div>`
       ))}
     </div>`

--- a/fastify-htmx/client/views/index.jsx
+++ b/fastify-htmx/client/views/index.jsx
@@ -32,7 +32,6 @@ export default function () {
     <div id="wrapper">
       {tiles.map((tile) => (
         <div
-          key={tile.id}
           class="tile"
           style={{
             left: `${tile.x}px`,

--- a/solid/client/base.jsx
+++ b/solid/client/base.jsx
@@ -5,6 +5,7 @@ export function createApp() {
   const centerX = wrapperWidth / 2
   const centerY = wrapperHeight / 2
 
+  let idCounter = 0
   let angle = 0
   let radius = 0
   const tiles = []
@@ -17,7 +18,7 @@ export function createApp() {
     y = centerY + Math.sin(angle) * radius
 
     if (x >= 0 && x <= wrapperWidth - cellSize && y >= 0 && y <= wrapperHeight - cellSize) {
-      tiles.push({ x, y })
+      tiles.push({ x, y, id: idCounter++ })
     }
 
     angle += 0.2

--- a/svelte/client/page.svelte
+++ b/svelte/client/page.svelte
@@ -5,6 +5,7 @@
   const centerX = wrapperWidth / 2
   const centerY = wrapperHeight / 2
 
+  let idCounter = 0
   let angle = 0
   let radius = 0
 
@@ -16,7 +17,7 @@
     let y = centerY + Math.sin(angle) * radius
 
     if (x >= 0 && x <= wrapperWidth - cellSize && y >= 0 && y <= wrapperHeight - cellSize) {
-      tiles.push({ x, y })
+      tiles.push({ x, y, id: idCounter++ })
     }
 
     angle += 0.2
@@ -25,10 +26,10 @@
 </script>
 
 <div id="wrapper">
-  {#each tiles as { x, y }}
+  {#each tiles as tile (tile.id)}
     <div
       class="tile"
-      style="left: {x}px; top: {y}px;"
+      style="left: {tile.x}px; top: {tile.y}px;"
     ></div>
   {/each}
 </div>

--- a/vue/package.json
+++ b/vue/package.json
@@ -10,7 +10,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@fastify/vite": "^",
+    "@fastify/vite": "^6.0.7",
     "fastify": "^4.24.3",
     "vue": "^3.4.38"
   },


### PR DESCRIPTION
This PR implements what I refer to in #16. While it leaves Solid basically holding the bag on serialization due to our hydration mechanism I think it is fair. We also are the only hydration implementation that doesn't use id keyed lists (but they are keyed) but that's part of the tradeoff. 

The end result is at least locally fastify-html takes the crown again as I'd expect it to. Although I imagine hydratable frameworks with hydration disabled should give it a run for its money.