### PR TITLE
Add uhtml

### DIFF
--- a/uhtml/client/base.js
+++ b/uhtml/client/base.js
@@ -1,0 +1,30 @@
+export function createApp(html) {
+  const wrapperWidth = 960;
+  const wrapperHeight = 720;
+  const cellSize = 10;
+  const centerX = wrapperWidth / 2;
+  const centerY = wrapperHeight / 2;
+
+  let angle = 0;
+  let radius = 0;
+
+  const tiles = [];
+  const step = cellSize;
+
+  while (radius < Math.min(wrapperWidth, wrapperHeight) / 2) {
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
+
+    if (x >= 0 && x <= wrapperWidth - cellSize && y >= 0 && y <= wrapperHeight - cellSize)
+      tiles.push({ x, y });
+
+    angle += 0.2;
+    radius += step * 0.015;
+  }
+
+  return html`
+    <div id="wrapper">${tiles.map(({ x, y }) => html`
+      <div class="tile" style=${`left: ${x.toFixed(2)}px; top: ${y.toFixed(2)}px`} />
+    `)}</div>
+  `;
+}

--- a/uhtml/client/index.html
+++ b/uhtml/client/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      background-color: #f0f0f0;
+      margin: 0;
+    }
+    #wrapper {
+      width: 960px;
+      height: 720px;
+      position: relative;
+      background-color: white;
+    }
+    .tile {
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      background-color: #333;
+    }
+    </style>
+    <!-- head -->
+  </head>
+  <body>
+    <!-- hydration -->
+    <div id="root"><!-- element --></div>
+    <script type="module" src="/mount.js"></script>
+  </body>
+</html>

--- a/uhtml/client/index.js
+++ b/uhtml/client/index.js
@@ -1,0 +1,6 @@
+import { createApp } from './base.js';
+
+export default {
+  // Provides function needed to perform SSR
+  createApp
+}

--- a/uhtml/client/mount.js
+++ b/uhtml/client/mount.js
@@ -1,0 +1,7 @@
+import { render, html } from 'uhtml';
+import { createApp } from './base.js';
+
+render(
+  document.getElementById('root'),
+  createApp(html)
+);

--- a/uhtml/package.json
+++ b/uhtml/package.json
@@ -1,0 +1,21 @@
+{
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js --dev",
+    "start": "node server.js",
+    "build": "npm run build:client && npm run build:server",
+    "build:client": "vite build --outDir dist/client --ssrManifest",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@fastify/vite": "^6.0.7",
+    "fastify": "^4.28.1",
+    "uhtml": "^4.5.11",
+    "uhtml-ssr": "^0.9.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.1"
+  }
+}

--- a/uhtml/server.js
+++ b/uhtml/server.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import Fastify from 'fastify';
+import FastifyVite from '@fastify/vite';
+import { render, html } from 'uhtml-ssr';
+
+// This example is based on uhtml/dom which offers much more
+// than just strings, which is this benchmark use case.
+// With this it'd be 3K instead of 5K requests with autocannon.
+// import uhtml from 'uhtml/ssr';
+// const { document, render, html } = uhtml('...');
+
+export async function main (dev) {
+  const server = Fastify();
+
+  await server.register(FastifyVite, {
+    root: import.meta.url,
+    dev: dev || process.argv.includes('--dev'),
+    createRenderFunction ({ createApp }) {
+      return () => ({
+        // with uhtml/dom instead it'd be:
+        // element: render(document.body, createApp(html)).innerHTML,
+        element: render(String, createApp(html))
+      });
+    }
+  });
+
+  server.get('/', (_, reply) => reply.html())
+
+  await server.vite.ready();
+  return server;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = await main();
+  await server.listen({ port: 3000 });
+}

--- a/uhtml/server.test.js
+++ b/uhtml/server.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { makeSSRBuildTest, makeIndexTest } from '../test-factories.mjs'
+import { main } from './server.js'
+
+const cwd = dirname(fileURLToPath(import.meta.url))
+
+test('render index page in development', () => makeIndexTest({ main, dev: true }))
+test('build production bundle', makeSSRBuildTest({ cwd, clientModules: 25, serverModules: 2 }))
+test('render index page in production', makeIndexTest({ main }))

--- a/uhtml/vite.config.js
+++ b/uhtml/vite.config.js
@@ -1,0 +1,12 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const path = fileURLToPath(import.meta.url);
+const root = resolve(dirname(path), 'client');
+
+const plugins = [];
+
+export default {
+  root,
+  plugins
+};


### PR DESCRIPTION
With autocannon

```
❯ autocannon http://localhost:3000

Running 10s test @ http://localhost:3000
10 connections


┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬───────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max   │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼───────┤
│ Latency │ 20 ms │ 21 ms │ 44 ms │ 47 ms │ 23.79 ms │ 7.46 ms │ 89 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 359     │ 359     │ 420     │ 431     │ 411     │ 23.68   │ 359     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 60.6 MB │ 60.6 MB │ 70.8 MB │ 72.7 MB │ 69.3 MB │ 3.99 MB │ 60.5 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

5k requests in 11.02s, 762 MB read
```

which is better than Preact *on my machine*.